### PR TITLE
Added support for Ouster scans with uint16_t ring fields.

### DIFF
--- a/docs/details/config_template_note.md
+++ b/docs/details/config_template_note.md
@@ -68,10 +68,11 @@ Configor:
           Type: "AWR1843BOOST_CUSTOM"
           Weight: 10.0
     #   1.        Velodyne LiDARs: VLP_16_PACKET, VLP_POINTS
-    #   2.          Ouster LiDARs: OUSTER_POINTS
+    #   2.          Ouster LiDARs: OUSTER_POINTS (Ouster pointcloud with uint8_t ring field)
     #   3. Hesai Pandar XT LiDARs: PANDAR_XT_POINTS
     #   4.           Livox LiDARs: LIVOX_CUSTOM (the official 'xfer_format'=1, mid-360 and avia is recommend)
     #   5.       Robosense LiDARs: RSLIDAR_POINTS (tested on RS-Helios-16P)
+    #   6.          Ouster LiDARs: OUSTER_POINTS_RING_16 (Ouster pointcloud with uint16_t ring field)
     LiDARTopics:
       # if no LiDAR is integrated in your sensor suite, just comment out the following key items
       - key: "/lidar0/scan"

--- a/docs/details/sensor_type.md
+++ b/docs/details/sensor_type.md
@@ -27,7 +27,7 @@ Currently, the following types of sensor are supported in `iKalibr`:
 + **LiDAR** type: corresponding type definition can be found [here](https://github.com/Unsigned-Long/iKalibr/blob/master/include/sensor/sensor_model.h#L109-L122). The type of LiDAR is more prone to error than others, most of the time error happens when decoding time stamps of points if the wrong LiDAR type is passed in `iKalibr`.
   + *Velodyne LiDARs*: `VLP_16_PACKET`, `VLP_POINTS`.
 
-  + *Ouster LiDARs*: `OUSTER_POINTS`.
+  + *Ouster LiDARs*: `OUSTER_POINTS`, `OUSTER_POINTS_RING_16`.
 
   + *Hesai Pandar XT LiDARs*: `PANDAR_XT_POINTS`.
 

--- a/include/sensor/lidar_data_loader.h
+++ b/include/sensor/lidar_data_loader.h
@@ -188,6 +188,18 @@ public:
     LiDARFrame::Ptr UnpackScan(const rosbag::MessageInstance &msgInstance) override;
 };
 
+class OusterRing16LiDAR : public LiDARDataLoader {
+public:
+    using Ptr = std::shared_ptr<OusterRing16LiDAR>;
+
+public:
+    explicit OusterRing16LiDAR(LidarModelType lidarModel);
+
+    static OusterRing16LiDAR::Ptr Create(LidarModelType lidarModel);
+
+    LiDARFrame::Ptr UnpackScan(const rosbag::MessageInstance &msgInstance) override;
+};
+
 class PandarXTLiDAR : public LiDARDataLoader {
 public:
     using Ptr = std::shared_ptr<PandarXTLiDAR>;

--- a/include/sensor/sensor_model.h
+++ b/include/sensor/sensor_model.h
@@ -118,6 +118,8 @@ struct LidarModel {
         LIVOX_CUSTOM,
 
         RSLIDAR_POINTS,
+
+	OUSTER_POINTS_RING_16,
     };
 
     static std::string UnsupportedLiDARModelMsg(const std::string &modelStr);

--- a/include/util/cloud_define.hpp
+++ b/include/util/cloud_define.hpp
@@ -112,6 +112,25 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(PointXYZIR8Y,
                                  (std::uint8_t, ring, ring)
                                  (std::uint32_t, t, t))
 
+// OUSTER lidar with uint16_t ring
+struct EIGEN_ALIGN16 PointXYZIR16Y {
+    PCL_ADD_POINT4D;   // quad-word XYZ
+    float intensity;   // laser intensity reading
+    std::uint16_t ring; // laser ring number
+    std::uint32_t t;
+    float range;
+
+    PCL_MAKE_ALIGNED_OPERATOR_NEW // ensure proper alignment
+};
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(PointXYZIR16Y,
+                                 (float, x, x)
+                                 (float, y, y)
+                                 (float, z, z)
+                                 (float, intensity, intensity)
+                                 (std::uint16_t, ring, ring)
+                                 (std::uint32_t, t, t))
+
 struct EIGEN_ALIGN16 PointXYZITR {
     PCL_ADD_POINT4D;
     float intensity;
@@ -146,6 +165,9 @@ using PosITPointCloud = pcl::PointCloud<PosITPoint>;
 
 using OusterPoint = PointXYZIR8Y;
 using OusterPointCloud = pcl::PointCloud<OusterPoint>;
+
+using OusterRing16Point = PointXYZIR16Y;
+using OusterRing16PointCloud = pcl::PointCloud<OusterRing16Point>;
 
 using ColorPoint = pcl::PointXYZRGBA;
 using ColorPointCloud = pcl::PointCloud<ColorPoint>;

--- a/src/sensor/sensor_model.cpp
+++ b/src/sensor/sensor_model.cpp
@@ -113,8 +113,11 @@ std::string LidarModel::UnsupportedLiDARModelMsg(const std::string &modelStr) {
         "3. Hesai Pandar XT LiDARs: PANDAR_XT_POINTS\n"
         "4.           Livox LiDARs: LIVOX_CUSTOM (the official 'xfer_format'=1, "
         "mid-360 and avia is recommend)\n"
+	"5.       Robosense LiDARs: RSLIDAR_POINTS (tested on RS-Helios-16P)\n"
+        "6.          Ouster LiDARs: OUSTER_POINTS_RING_16 (Ouster pointcloud with "
+	"uint16_t ring field)"
         "...\n"
-        "If you need to use other IMU types, "
+        "If you need to use other LiDAR types, "
         "please 'Issues' us on the profile of the github repository.",
         modelStr);
 }


### PR DESCRIPTION
PR https://github.com/ouster-lidar/ouster-ros/pull/40 changed `ring` field in Ouster pointclouds from uint8_t to uint16_t. This PR adds support for this new point cloud format.