### PR TITLE
Many improvements regarding priori information (to speed up optimization and allow usage of prior estimates)

### DIFF
--- a/config/ikalibr-config.yaml
+++ b/config/ikalibr-config.yaml
@@ -141,11 +141,17 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters
     # by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/config/ikalibr-config.yaml
+++ b/config/ikalibr-config.yaml
@@ -144,6 +144,8 @@ Configor:
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters
     # by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/config/spat-temp-priori.yaml
+++ b/config/spat-temp-priori.yaml
@@ -48,3 +48,15 @@ SpatialTemporalPriori:
   # readout time of another rs camera
   # - key: /sensor2/topic
   #   value: 0.02
+  MIN_VISUAL_SCALE:
+  # if set for a camera sensor, this is the lower bound for the estimated visual scale.
+  # if not set, the minimum visual scale is 0.001
+  #- key: "/sensor1/topic"
+  #  value: 0.9
+  GRAVITY:
+  # the direction of the gravity vector in the reference IMU when it is in its default,
+  # gravity-aligned position. The magnitude of the vector should correspond to the magnitude
+  # set in ikalibr config. This is just an initialization value and it will be further optimized.
+    r0c0: 0.0
+    r1c0: 0.0
+    r2c0: -9.8

--- a/config/spat-temp-priori.yaml
+++ b/config/spat-temp-priori.yaml
@@ -60,3 +60,12 @@ SpatialTemporalPriori:
     r0c0: 0.0
     r1c0: 0.0
     r2c0: -9.8
+  INTRI_WEIGHTS:
+  # these weights specify how much should the optimized intrinsics stick to their priors given as
+  # camera or IMU configs in the ikalibr config file.
+  # - key: "/camera1"
+  #   value: 1000
+  # - key: "/camera2"
+  #   value: 1
+  # - key: "/imu1"
+  #   value: 10000

--- a/data/li-calib/Court-01/config-real.yaml
+++ b/data/li-calib/Court-01/config-real.yaml
@@ -67,6 +67,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Court-01/config-real.yaml
+++ b/data/li-calib/Court-01/config-real.yaml
@@ -65,10 +65,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Court-02/config-real.yaml
+++ b/data/li-calib/Court-02/config-real.yaml
@@ -67,6 +67,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Court-02/config-real.yaml
+++ b/data/li-calib/Court-02/config-real.yaml
@@ -65,10 +65,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Court-03/config-real.yaml
+++ b/data/li-calib/Court-03/config-real.yaml
@@ -67,6 +67,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Court-03/config-real.yaml
+++ b/data/li-calib/Court-03/config-real.yaml
@@ -65,10 +65,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Court-04/config-real.yaml
+++ b/data/li-calib/Court-04/config-real.yaml
@@ -67,6 +67,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Court-04/config-real.yaml
+++ b/data/li-calib/Court-04/config-real.yaml
@@ -65,10 +65,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Court-05/config-real.yaml
+++ b/data/li-calib/Court-05/config-real.yaml
@@ -67,6 +67,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Court-05/config-real.yaml
+++ b/data/li-calib/Court-05/config-real.yaml
@@ -65,10 +65,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Garage-01/config-real.yaml
+++ b/data/li-calib/Garage-01/config-real.yaml
@@ -67,6 +67,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Garage-01/config-real.yaml
+++ b/data/li-calib/Garage-01/config-real.yaml
@@ -65,10 +65,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Garage-02/config-real.yaml
+++ b/data/li-calib/Garage-02/config-real.yaml
@@ -67,6 +67,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Garage-02/config-real.yaml
+++ b/data/li-calib/Garage-02/config-real.yaml
@@ -65,10 +65,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Garage-03/config-real.yaml
+++ b/data/li-calib/Garage-03/config-real.yaml
@@ -67,6 +67,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Garage-03/config-real.yaml
+++ b/data/li-calib/Garage-03/config-real.yaml
@@ -65,10 +65,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Garage-04/config-real.yaml
+++ b/data/li-calib/Garage-04/config-real.yaml
@@ -67,6 +67,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Garage-04/config-real.yaml
+++ b/data/li-calib/Garage-04/config-real.yaml
@@ -65,10 +65,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Garage-05/config-real.yaml
+++ b/data/li-calib/Garage-05/config-real.yaml
@@ -67,6 +67,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/li-calib/Garage-05/config-real.yaml
+++ b/data/li-calib/Garage-05/config-real.yaml
@@ -65,10 +65,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-14-52-11/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-14-52-11/config-real.yaml
@@ -84,6 +84,8 @@ Configor:
     SpatTempPrioriPath: "/home/csl/ros_ws/iKalibr/src/ikalibr/config/spat-temp-priori.yaml"
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-14-52-11/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-14-52-11/config-real.yaml
@@ -86,6 +86,8 @@ Configor:
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-14-55-10/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-14-55-10/config-real.yaml
@@ -84,6 +84,8 @@ Configor:
     SpatTempPrioriPath: "/home/csl/ros_ws/iKalibr/src/ikalibr/config/spat-temp-priori.yaml"
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-14-55-10/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-14-55-10/config-real.yaml
@@ -86,6 +86,8 @@ Configor:
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-15-22-04/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-15-22-04/config-real.yaml
@@ -68,6 +68,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-15-22-04/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-15-22-04/config-real.yaml
@@ -66,10 +66,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-15-30-05/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-15-30-05/config-real.yaml
@@ -68,6 +68,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-15-30-05/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-15-30-05/config-real.yaml
@@ -66,10 +66,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-16-34-01/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-16-34-01/config-real.yaml
@@ -68,6 +68,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-16-34-01/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-16-34-01/config-real.yaml
@@ -66,10 +66,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-16-42-32/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-16-42-32/config-real.yaml
@@ -86,6 +86,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-16-42-32/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-16-42-32/config-real.yaml
@@ -84,10 +84,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-16-44-05/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-16-44-05/config-real.yaml
@@ -86,6 +86,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-16-44-05/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-16-44-05/config-real.yaml
@@ -84,10 +84,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-16-49-39/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-16-49-39/config-real.yaml
@@ -61,10 +61,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-16-49-39/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-16-49-39/config-real.yaml
@@ -63,6 +63,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-16-55-29/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-16-55-29/config-real.yaml
@@ -82,6 +82,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-16-55-29/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-16-55-29/config-real.yaml
@@ -80,10 +80,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-17-10-20/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-17-10-20/config-real.yaml
@@ -82,10 +82,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-17-10-20/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-17-10-20/config-real.yaml
@@ -84,6 +84,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-17-12-05/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-17-12-05/config-real.yaml
@@ -82,10 +82,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-17-12-05/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-17-12-05/config-real.yaml
@@ -84,6 +84,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-17-17-17/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-17-17-17/config-real.yaml
@@ -68,6 +68,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-17-17-17/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-17-17-17/config-real.yaml
@@ -66,10 +66,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-17-33-29/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-17-33-29/config-real.yaml
@@ -68,6 +68,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-17-33-29/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-17-33-29/config-real.yaml
@@ -66,10 +66,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-17-37-20/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-17-37-20/config-real.yaml
@@ -78,10 +78,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/real-world/iKalibr-data-2024-06-25-17-37-20/config-real.yaml
+++ b/data/real-world/iKalibr-data-2024-06-25-17-37-20/config-real.yaml
@@ -80,6 +80,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/river/data_202392614595/config-real.yaml
+++ b/data/river/data_202392614595/config-real.yaml
@@ -59,6 +59,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/river/data_202392614595/config-real.yaml
+++ b/data/river/data_202392614595/config-real.yaml
@@ -57,10 +57,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/river/data_202392615561/config-real.yaml
+++ b/data/river/data_202392615561/config-real.yaml
@@ -59,6 +59,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/river/data_202392615561/config-real.yaml
+++ b/data/river/data_202392615561/config-real.yaml
@@ -57,10 +57,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/river/data_202392616822/config-real.yaml
+++ b/data/river/data_202392616822/config-real.yaml
@@ -59,6 +59,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/river/data_202392616822/config-real.yaml
+++ b/data/river/data_202392616822/config-real.yaml
@@ -57,10 +57,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-1/config-real.yaml
+++ b/data/tum/rs-seq-1/config-real.yaml
@@ -61,10 +61,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-1/config-real.yaml
+++ b/data/tum/rs-seq-1/config-real.yaml
@@ -63,6 +63,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-10/config-real.yaml
+++ b/data/tum/rs-seq-10/config-real.yaml
@@ -61,10 +61,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-10/config-real.yaml
+++ b/data/tum/rs-seq-10/config-real.yaml
@@ -63,6 +63,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-2/config-real.yaml
+++ b/data/tum/rs-seq-2/config-real.yaml
@@ -61,10 +61,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-2/config-real.yaml
+++ b/data/tum/rs-seq-2/config-real.yaml
@@ -63,6 +63,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-3/config-real.yaml
+++ b/data/tum/rs-seq-3/config-real.yaml
@@ -61,10 +61,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-3/config-real.yaml
+++ b/data/tum/rs-seq-3/config-real.yaml
@@ -63,6 +63,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-4/config-real.yaml
+++ b/data/tum/rs-seq-4/config-real.yaml
@@ -61,10 +61,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-4/config-real.yaml
+++ b/data/tum/rs-seq-4/config-real.yaml
@@ -63,6 +63,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-5/config-real.yaml
+++ b/data/tum/rs-seq-5/config-real.yaml
@@ -61,10 +61,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-5/config-real.yaml
+++ b/data/tum/rs-seq-5/config-real.yaml
@@ -63,6 +63,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-6/config-real.yaml
+++ b/data/tum/rs-seq-6/config-real.yaml
@@ -61,10 +61,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-6/config-real.yaml
+++ b/data/tum/rs-seq-6/config-real.yaml
@@ -63,6 +63,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-7/config-real.yaml
+++ b/data/tum/rs-seq-7/config-real.yaml
@@ -61,10 +61,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-7/config-real.yaml
+++ b/data/tum/rs-seq-7/config-real.yaml
@@ -63,6 +63,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-8/config-real.yaml
+++ b/data/tum/rs-seq-8/config-real.yaml
@@ -61,10 +61,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-8/config-real.yaml
+++ b/data/tum/rs-seq-8/config-real.yaml
@@ -63,6 +63,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-9/config-real.yaml
+++ b/data/tum/rs-seq-9/config-real.yaml
@@ -61,10 +61,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/tum/rs-seq-9/config-real.yaml
+++ b/data/tum/rs-seq-9/config-real.yaml
@@ -63,6 +63,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: false
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/vector/desk-fast/config-real.yaml
+++ b/data/vector/desk-fast/config-real.yaml
@@ -95,6 +95,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/vector/desk-fast/config-real.yaml
+++ b/data/vector/desk-fast/config-real.yaml
@@ -93,10 +93,16 @@ Configor:
     GravityNorm: 9.79
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/vector/hdr-fast/config-real.yaml
+++ b/data/vector/hdr-fast/config-real.yaml
@@ -90,6 +90,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/vector/hdr-fast/config-real.yaml
+++ b/data/vector/hdr-fast/config-real.yaml
@@ -88,10 +88,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/vector/mountain-fast/config-real.yaml
+++ b/data/vector/mountain-fast/config-real.yaml
@@ -90,6 +90,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/vector/mountain-fast/config-real.yaml
+++ b/data/vector/mountain-fast/config-real.yaml
@@ -88,10 +88,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/vector/robot-fast/config-real.yaml
+++ b/data/vector/robot-fast/config-real.yaml
@@ -90,6 +90,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/vector/robot-fast/config-real.yaml
+++ b/data/vector/robot-fast/config-real.yaml
@@ -88,10 +88,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/vector/sofa-fast/config-real.yaml
+++ b/data/vector/sofa-fast/config-real.yaml
@@ -90,6 +90,8 @@ Configor:
     SpatTempPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/data/vector/sofa-fast/config-real.yaml
+++ b/data/vector/sofa-fast/config-real.yaml
@@ -88,10 +88,16 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/docs/details/config_template_note.md
+++ b/docs/details/config_template_note.md
@@ -68,10 +68,11 @@ Configor:
           Type: "AWR1843BOOST_CUSTOM"
           Weight: 10.0
     #   1.        Velodyne LiDARs: VLP_16_PACKET, VLP_POINTS
-    #   2.          Ouster LiDARs: OUSTER_POINTS
+    #   2.          Ouster LiDARs: OUSTER_POINTS (Ouster pointcloud with uint8_t ring field)
     #   3. Hesai Pandar XT LiDARs: PANDAR_XT_POINTS
     #   4.           Livox LiDARs: LIVOX_CUSTOM (the official 'xfer_format'=1, mid-360 and avia is recommend)
     #   5.       Robosense LiDARs: RSLIDAR_POINTS (tested on RS-Helios-16P)
+    #   6.          Ouster LiDARs: OUSTER_POINTS_RING_16 (Ouster pointcloud with uint16_t ring field)
     LiDARTopics:
       # if no LiDAR is integrated in your sensor suite, just comment out the following key items
       - key: "/lidar0/scan"

--- a/docs/details/config_template_note.md
+++ b/docs/details/config_template_note.md
@@ -165,6 +165,8 @@ Configor:
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters
     # by setting this field to 'false'
     OptTemporalParams: true
+    # if true, the last batch optimization will also optimize IMU nonlinearities
+    OptImuNonlinearity: false
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/docs/details/config_template_note.md
+++ b/docs/details/config_template_note.md
@@ -162,11 +162,17 @@ Configor:
     GravityNorm: 9.8
     # priori about spatiotemporal parameters, given by corresponding config file path
     SpatTempPrioriPath: ""
+    # if nonempty, this should point to a knots.yaml file saved by a previous run of ikalibr
+    # splines will be loaded and initialized from these priors and their knots with priors
+    # will not be optimized (unless OptSplines is true)
+    SplinesPrioriPath: ""
     # if sensor are hardware-synchronized, you could choose to fix temporal parameters
     # by setting this field to 'false'
     OptTemporalParams: true
     # if true, the last batch optimization will also optimize IMU nonlinearities
     OptImuNonlinearity: false
+    # if true, even spline knots with priori information will be optimized
+    OptSplines: true
     # the range where the time offsets would be optimized.
     # make sure this range contains the ground truth of time offsets
     # If you're not sure, make this field large, but this could lead to longer optimization time

--- a/docs/details/sensor_type.md
+++ b/docs/details/sensor_type.md
@@ -27,7 +27,7 @@ Currently, the following types of sensor are supported in `iKalibr`:
 + **LiDAR** type: corresponding type definition can be found [here](https://github.com/Unsigned-Long/iKalibr/blob/master/include/sensor/sensor_model.h#L109-L122). The type of LiDAR is more prone to error than others, most of the time error happens when decoding time stamps of points if the wrong LiDAR type is passed in `iKalibr`.
   + *Velodyne LiDARs*: `VLP_16_PACKET`, `VLP_POINTS`.
 
-  + *Ouster LiDARs*: `OUSTER_POINTS`.
+  + *Ouster LiDARs*: `OUSTER_POINTS`, `OUSTER_POINTS_RING_16`.
 
   + *Hesai Pandar XT LiDARs*: `PANDAR_XT_POINTS`.
 

--- a/include/calib/calib_param_manager.h
+++ b/include/calib/calib_param_manager.h
@@ -213,6 +213,10 @@ public:
         std::map<std::string, ns_veta::PinholeIntrinsic::Ptr> Camera;
         std::map<std::string, RGBDIntrinsics::Ptr> RGBD;
 
+        std::map<std::string, IMUIntrinsics::Ptr> PrioriIMU;
+        std::map<std::string, ns_veta::PinholeIntrinsic::Ptr> PrioriCamera;
+        std::map<std::string, RGBDIntrinsics::Ptr> PrioriRGBD;
+
         static ns_veta::PinholeIntrinsic::Ptr LoadCameraIntri(
             const std::string &filename,
             CerealArchiveType::Enum archiveType = CerealArchiveType::Enum::YAML);

--- a/include/calib/calib_param_manager.h
+++ b/include/calib/calib_param_manager.h
@@ -249,6 +249,9 @@ public:
     // S2Manifold
     Eigen::Vector3d GRAVITY;
 
+    // true for every knot that has been loaded from priori information
+    std::map<std::string, std::vector<bool>> splinesPrioriKnots;
+
 public:
     // the constructor
     explicit CalibParamManager(const std::vector<std::string> &imuTopics = {},

--- a/include/calib/estimator.h
+++ b/include/calib/estimator.h
@@ -485,6 +485,17 @@ public:
                                       double *TO_Sen2ToRef,
                                       double weight);
 
+    void AddPriorEqualityConstraint(const double *prior, double *address, double weight);
+    void AddPriorEqualityConstraint(const Eigen::Vector3d &prior,
+                                    Eigen::Vector3d &address,
+                                    double weight);
+    void AddPriorEqualityConstraint(const Eigen::Vector6d &prior,
+                                    Eigen::Vector6d &address,
+                                    double weight);
+    void AddPriorEqualityConstraint(const Sophus::SO3d &prior,
+                                    Sophus::SO3d &address,
+                                    double weight);
+
     void PrintUninvolvedKnots() const;
 
     void AddVisualVelocityDepthFactor(Eigen::Vector3d *LIN_VEL_CmToWInCm,

--- a/include/calib/spat_temp_priori.h
+++ b/include/calib/spat_temp_priori.h
@@ -64,6 +64,7 @@ public:
     std::map<std::string, double> RS_READOUT;
     Eigen::Vector3d GRAVITY;
     std::map<std::string, double> MIN_VISUAL_SCALE;
+    std::map<std::string, double> INTRI_WEIGHTS;
 
 public:
     SpatialTemporalPriori() = default;

--- a/include/calib/spat_temp_priori.h
+++ b/include/calib/spat_temp_priori.h
@@ -62,6 +62,8 @@ public:
     std::map<FromTo, double> TO_Sen1ToSen2;
     // readout time of rs cameras
     std::map<std::string, double> RS_READOUT;
+    Eigen::Vector3d GRAVITY;
+    std::map<std::string, double> MIN_VISUAL_SCALE;
 
 public:
     SpatialTemporalPriori() = default;
@@ -75,6 +77,10 @@ public:
     [[nodiscard]] const std::map<FromTo, double> &GetTimeOffset() const;
 
     [[nodiscard]] const std::map<std::string, double> &GetReadout() const;
+
+    [[nodiscard]] std::optional<Eigen::Vector3d> GetGravity() const;
+
+    [[nodiscard]] const std::map<std::string, double> &GetMinVisualScale() const;
 
     [[nodiscard]] bool HasSO3ToBr(const std::string& topic) const;
 
@@ -116,7 +122,7 @@ public:
     template <class Archive>
     void serialize(Archive &ar) {
         ar(CEREAL_NVP(SO3_Sen1ToSen2), CEREAL_NVP(POS_Sen1InSen2), CEREAL_NVP(TO_Sen1ToSen2),
-           CEREAL_NVP(RS_READOUT));
+           CEREAL_NVP(RS_READOUT), CEREAL_NVP(GRAVITY), CEREAL_NVP(MIN_VISUAL_SCALE));
     }
 
     // save the parameters to file using cereal library

--- a/include/calib/spat_temp_priori.h
+++ b/include/calib/spat_temp_priori.h
@@ -76,6 +76,18 @@ public:
 
     [[nodiscard]] const std::map<std::string, double> &GetReadout() const;
 
+    [[nodiscard]] bool HasSO3ToBr(const std::string& topic) const;
+
+    [[nodiscard]] std::optional<Sophus::SO3d> GetSO3ToBr(const std::string& topic) const;
+
+    [[nodiscard]] bool HasPosInBr(const std::string& topic) const;
+
+    [[nodiscard]] std::optional<Eigen::Vector3d> GetPosInBr(const std::string& topic) const;
+
+    [[nodiscard]] bool HasTOToBr(const std::string& topic) const;
+
+    [[nodiscard]] std::optional<double> GetTOToBr(const std::string& topic) const;
+
     void CheckValidityWithConfigor() const;
 
     void AddSpatTempPrioriConstraint(Estimator &estimator, CalibParamManager &parMagr) const;
@@ -93,6 +105,11 @@ protected:
         }
         return {false, {}};
     }
+
+private:
+    mutable std::set<std::string> hasSO3ToBr;
+    mutable std::set<std::string> hasPosToBr;
+    mutable std::set<std::string> hasTOToBr;
 
 public:
     // Serialization

--- a/include/config/configor.h
+++ b/include/config/configor.h
@@ -254,9 +254,11 @@ public:
 
     static struct Prior {
         static std::string SpatTempPrioriPath;
+        static std::string SplinesPrioriPath;
         static double GravityNorm;
         static constexpr int SplineOrder = 4;
         static bool OptTemporalParams;
+        static bool OptSplines;
         static bool OptImuNonlinearity;
         static double TimeOffsetPadding;
         static double ReadoutTimePadding;
@@ -320,7 +322,8 @@ public:
             ar(CEREAL_NVP(SpatTempPrioriPath), CEREAL_NVP(GravityNorm),
                CEREAL_NVP(OptTemporalParams), CEREAL_NVP(TimeOffsetPadding),
                CEREAL_NVP(ReadoutTimePadding), CEREAL_NVP(MapDownSample),
-               CEREAL_NVP(OptImuNonlinearity),
+               CEREAL_NVP(OptImuNonlinearity), CEREAL_NVP(SplinesPrioriPath),
+               CEREAL_NVP(OptSplines),
                cereal::make_nvp("KnotTimeDist", knotTimeDist),
                cereal::make_nvp("NDTLiDAROdometer", ndtLiDAROdometer),
                cereal::make_nvp("LiDARDataAssociate", lidarDataAssociate));

--- a/include/config/configor.h
+++ b/include/config/configor.h
@@ -257,6 +257,7 @@ public:
         static double GravityNorm;
         static constexpr int SplineOrder = 4;
         static bool OptTemporalParams;
+        static bool OptImuNonlinearity;
         static double TimeOffsetPadding;
         static double ReadoutTimePadding;
         static double MapDownSample;
@@ -319,6 +320,7 @@ public:
             ar(CEREAL_NVP(SpatTempPrioriPath), CEREAL_NVP(GravityNorm),
                CEREAL_NVP(OptTemporalParams), CEREAL_NVP(TimeOffsetPadding),
                CEREAL_NVP(ReadoutTimePadding), CEREAL_NVP(MapDownSample),
+               CEREAL_NVP(OptImuNonlinearity),
                cereal::make_nvp("KnotTimeDist", knotTimeDist),
                cereal::make_nvp("NDTLiDAROdometer", ndtLiDAROdometer),
                cereal::make_nvp("LiDARDataAssociate", lidarDataAssociate));

--- a/include/factor/prior_equality_factor.hpp
+++ b/include/factor/prior_equality_factor.hpp
@@ -1,0 +1,103 @@
+// iKalibr: Unified Targetless Spatiotemporal Calibration Framework
+// Copyright 2024, the School of Geodesy and Geomatics (SGG), Wuhan University, China
+// https://github.com/Unsigned-Long/iKalibr.git
+//
+// Author: Shuolong Chen (shlchen@whu.edu.cn)
+// GitHub: https://github.com/Unsigned-Long
+//  ORCID: 0000-0002-5283-9057
+//
+// Purpose: See .h/.hpp file.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice,
+//   this list of conditions and the following disclaimer.
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+// * The names of its contributors can not be
+//   used to endorse or promote products derived from this software without
+//   specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef IKALIBR_PRIOR_EQUALITY_FACTOR_HPP
+#define IKALIBR_PRIOR_EQUALITY_FACTOR_HPP
+
+#include "ctraj/utils/eigen_utils.hpp"
+#include "ctraj/utils/sophus_utils.hpp"
+#include "ceres/dynamic_autodiff_cost_function.h"
+#include "util/utils.h"
+
+namespace {
+bool IKALIBR_UNIQUE_NAME(_2_) = ns_ikalibr::_1_(__FILE__);
+}
+
+namespace ns_ikalibr {
+template<int PriorSize>
+struct PriorEqualityFactor {
+private:
+    const double* _prior;
+    double _weight;
+
+public:
+    explicit PriorEqualityFactor(const double *prior, double weight)
+        : _prior(prior),
+          _weight(weight) {}
+
+    static auto Create(const double *prior, double weight) {
+        return new ceres::DynamicAutoDiffCostFunction<PriorEqualityFactor>(
+            new PriorEqualityFactor<1>(prior, weight));
+    }
+
+    static auto Create(const Eigen::Vector3d &prior, double weight) {
+        return new ceres::DynamicAutoDiffCostFunction<PriorEqualityFactor>(
+            new PriorEqualityFactor<3>(prior.data(), weight));
+    }
+
+    static auto Create(const Eigen::Vector6d &prior, double weight) {
+        return new ceres::DynamicAutoDiffCostFunction<PriorEqualityFactor>(
+            new PriorEqualityFactor<6>(prior.data(), weight));
+    }
+
+    static auto Create(const Sophus::SO3d &prior, double weight) {
+        return new ceres::DynamicAutoDiffCostFunction<PriorEqualityFactor>(
+            new PriorEqualityFactor<4>(prior.data(), weight));
+    }
+
+    static std::size_t TypeHashCode() { return typeid(PriorEqualityFactor).hash_code(); }
+
+public:
+    /**
+     * param blocks:
+     * [ Prior | ... ]
+     */
+    template <class T>
+    bool operator()(T const *const *sKnots, T *sResiduals) const {
+        const T* const actual = sKnots[0];
+
+        Eigen::Map<Eigen::Vector<T, PriorSize>> residuals(sResiduals);
+        for (size_t i = 0; i < PriorSize; ++i) {
+            residuals(i) = T(_weight) * (_prior[i] - actual[i]);
+        }
+
+        return true;
+    }
+
+public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+};
+}  // namespace ns_ikalibr
+
+#endif  // IKALIBR_PRIOR_EQUALITY_FACTOR_HPP

--- a/include/sensor/lidar_data_loader.h
+++ b/include/sensor/lidar_data_loader.h
@@ -188,6 +188,18 @@ public:
     LiDARFrame::Ptr UnpackScan(const rosbag::MessageInstance &msgInstance) override;
 };
 
+class OusterRing16LiDAR : public LiDARDataLoader {
+public:
+    using Ptr = std::shared_ptr<OusterRing16LiDAR>;
+
+public:
+    explicit OusterRing16LiDAR(LidarModelType lidarModel);
+
+    static OusterRing16LiDAR::Ptr Create(LidarModelType lidarModel);
+
+    LiDARFrame::Ptr UnpackScan(const rosbag::MessageInstance &msgInstance) override;
+};
+
 class PandarXTLiDAR : public LiDARDataLoader {
 public:
     using Ptr = std::shared_ptr<PandarXTLiDAR>;

--- a/include/sensor/sensor_model.h
+++ b/include/sensor/sensor_model.h
@@ -118,6 +118,8 @@ struct LidarModel {
         LIVOX_CUSTOM,
 
         RSLIDAR_POINTS,
+
+	OUSTER_POINTS_RING_16,
     };
 
     static std::string UnsupportedLiDARModelMsg(const std::string &modelStr);

--- a/include/solver/batch_opt_option.hpp
+++ b/include/solver/batch_opt_option.hpp
@@ -137,6 +137,13 @@ public:
             if (Configor::IsEventIntegrated()) {
                 options = MergeOptions(options, AryToVecWithAppend(MultiEventIMU));
             }
+            // Optimize IMU nonlinearity in the last batch
+            if (!options.empty() && Configor::Prior::OptImuNonlinearity) {
+                auto& opt = options.back();
+                opt |= Opt::OPT_GYRO_MAP_COEFF;
+                opt |= Opt::OPT_ACCE_MAP_COEFF;
+                opt |= Opt::OPT_SO3_AtoG;
+            }
         }
         if (options.empty()) {
             throw Status(Status::CRITICAL, "unknown error happened! (unknown sensor suite)");

--- a/include/solver/calib_solver.h
+++ b/include/solver/calib_solver.h
@@ -232,6 +232,12 @@ public:
      */
     virtual ~CalibSolver();
 
+    /**
+     * get the raw timestamp of the beginning of the used data
+     * @return the timestamp
+     */
+    double GetRawStartTimestamp() const;
+
 protected:
     /**
      * transform an input veta using given transformation information, if scale is provide,
@@ -243,6 +249,12 @@ protected:
     static void PerformTransformForVeta(const ns_veta::VetaPtr &veta,
                                         const ns_veta::Posed &curToNew,
                                         double scale);
+
+    /**
+     * Load spline bundle priori data.
+     * @param splinesPrioriPath path to the file saved by CalibSolverIO::SaveBSplines()
+     */
+    void LoadSplineBundlePriori(const std::string& splinesPrioriPath);
 
     /**
      * align vectors to a new coordinate frame where gravity pointing to negative z-axis.

--- a/include/util/cloud_define.hpp
+++ b/include/util/cloud_define.hpp
@@ -112,6 +112,25 @@ POINT_CLOUD_REGISTER_POINT_STRUCT(PointXYZIR8Y,
                                  (std::uint8_t, ring, ring)
                                  (std::uint32_t, t, t))
 
+// OUSTER lidar with uint16_t ring
+struct EIGEN_ALIGN16 PointXYZIR16Y {
+    PCL_ADD_POINT4D;   // quad-word XYZ
+    float intensity;   // laser intensity reading
+    std::uint16_t ring; // laser ring number
+    std::uint32_t t;
+    float range;
+
+    PCL_MAKE_ALIGNED_OPERATOR_NEW // ensure proper alignment
+};
+
+POINT_CLOUD_REGISTER_POINT_STRUCT(PointXYZIR16Y,
+                                 (float, x, x)
+                                 (float, y, y)
+                                 (float, z, z)
+                                 (float, intensity, intensity)
+                                 (std::uint16_t, ring, ring)
+                                 (std::uint32_t, t, t))
+
 struct EIGEN_ALIGN16 PointXYZITR {
     PCL_ADD_POINT4D;
     float intensity;
@@ -146,6 +165,9 @@ using PosITPointCloud = pcl::PointCloud<PosITPoint>;
 
 using OusterPoint = PointXYZIR8Y;
 using OusterPointCloud = pcl::PointCloud<OusterPoint>;
+
+using OusterRing16Point = PointXYZIR16Y;
+using OusterRing16PointCloud = pcl::PointCloud<OusterRing16Point>;
 
 using ColorPoint = pcl::PointXYZRGBA;
 using ColorPointCloud = pcl::PointCloud<ColorPoint>;

--- a/src/calib/calib_param_manager.cpp
+++ b/src/calib/calib_param_manager.cpp
@@ -158,6 +158,22 @@ CalibParamManager::Ptr CalibParamManager::InitParamsFromConfigor() {
         }
     }
 
+    for (const auto& [topic, intri] : parMarg->INTRI.IMU) {
+        parMarg->INTRI.PrioriIMU[topic] = IMUIntrinsics::Create();
+        *parMarg->INTRI.PrioriIMU[topic] = *parMarg->INTRI.IMU[topic];
+    }
+    for (const auto& [topic, intri] : parMarg->INTRI.Camera) {
+        parMarg->INTRI.PrioriCamera[topic] = ns_veta::PinholeIntrinsic::Create(0, 0, 0, 0, 0, 0);
+        *parMarg->INTRI.PrioriCamera[topic] = *parMarg->INTRI.Camera[topic];
+    }
+    for (const auto& [topic, intri] : parMarg->INTRI.RGBD) {
+        parMarg->INTRI.PrioriRGBD[topic] = RGBDIntrinsics::Create(
+            ns_veta::PinholeIntrinsic::Create(0, 0, 0, 0, 0, 0), 0, 0);
+        *parMarg->INTRI.PrioriRGBD[topic]->intri = *parMarg->INTRI.RGBD[topic]->intri;
+        parMarg->INTRI.PrioriRGBD[topic]->alpha = parMarg->INTRI.RGBD[topic]->alpha;
+        parMarg->INTRI.PrioriRGBD[topic]->beta = parMarg->INTRI.RGBD[topic]->beta;
+    }
+
     // align to the negative 'z' axis
     parMarg->GRAVITY = Eigen::Vector3d(0.0, 0.0, -Configor::Prior::GravityNorm);
 

--- a/src/calib/estimator.cpp
+++ b/src/calib/estimator.cpp
@@ -106,6 +106,7 @@ void Estimator::AddRdKnotsData(std::vector<double *> &paramBlockVec,
                                const Estimator::SplineBundleType::RdSplineType &spline,
                                const Estimator::SplineMetaType &splineMeta,
                                bool setToConst) {
+    const auto& prioriKnots = parMagr->splinesPrioriKnots.at(Configor::Preference::SCALE_SPLINE);
     // for each segment
     for (const auto &seg : splineMeta.segments) {
         // the factor 'seg.dt * 0.5' is the treatment for numerical accuracy
@@ -119,7 +120,12 @@ void Estimator::AddRdKnotsData(std::vector<double *> &paramBlockVec,
 
             paramBlockVec.push_back(data);
             // set this param block to be constant
-            if (setToConst) {
+            bool setKnotToConst = setToConst;
+            if (!setToConst && !Configor::Prior::OptSplines) {
+                if (i < prioriKnots.size())
+                    setKnotToConst = prioriKnots.at(i);
+            }
+            if (setKnotToConst) {
                 this->SetParameterBlockConstant(data);
             }
         }
@@ -130,6 +136,7 @@ void Estimator::AddSo3KnotsData(std::vector<double *> &paramBlockVec,
                                 const Estimator::SplineBundleType::So3SplineType &spline,
                                 const Estimator::SplineMetaType &splineMeta,
                                 bool setToConst) {
+    const auto& prioriKnots = parMagr->splinesPrioriKnots.at(Configor::Preference::SO3_SPLINE);
     // for each segment
     for (const auto &seg : splineMeta.segments) {
         // the factor 'seg.dt * 0.5' is the treatment for numerical accuracy
@@ -143,7 +150,12 @@ void Estimator::AddSo3KnotsData(std::vector<double *> &paramBlockVec,
 
             paramBlockVec.push_back(data);
             // set this param block to be constant
-            if (setToConst) {
+            bool setKnotToConst = setToConst;
+            if (!setToConst && !Configor::Prior::OptSplines) {
+                if (i < prioriKnots.size())
+                    setKnotToConst = prioriKnots.at(i);
+            }
+            if (setKnotToConst) {
                 this->SetParameterBlockConstant(data);
             }
         }

--- a/src/calib/estimator.cpp
+++ b/src/calib/estimator.cpp
@@ -42,6 +42,7 @@
 #include "factor/linear_knots_factor.hpp"
 #include "factor/prior_extri_pos_factor.hpp"
 #include "factor/prior_extri_so3_factor.hpp"
+#include "factor/prior_equality_factor.hpp"
 #include "factor/prior_time_offset_factor.hpp"
 #include "factor/radar_inertial_align_factor.hpp"
 #include "factor/radar_inertial_rot_align_factor.hpp"
@@ -1817,6 +1818,88 @@ void Estimator::AddPriorTimeOffsetConstraint(const double &TO_Sen1ToSen2,
     paramBlockVec.push_back(TO_Sen1ToRef);
     // TO_Sen2ToRef
     paramBlockVec.push_back(TO_Sen2ToRef);
+
+    // pass to problem
+    this->AddResidualBlock(costFunc, nullptr, paramBlockVec);
+}
+
+void Estimator::AddPriorEqualityConstraint(const double *prior, double *address, double weight) {
+    // create a cost function
+    auto costFunc = PriorEqualityFactor<1>::Create(prior, weight);
+
+    // prior
+    costFunc->AddParameterBlock(1);
+
+    // set Residuals
+    costFunc->SetNumResiduals(1);
+
+    // organize the param block vector
+    std::vector<double *> paramBlockVec;
+
+    paramBlockVec.push_back(address);
+
+    // pass to problem
+    this->AddResidualBlock(costFunc, nullptr, paramBlockVec);
+}
+
+void Estimator::AddPriorEqualityConstraint(const Eigen::Vector3d &prior,
+                                           Eigen::Vector3d &address,
+                                           double weight) {
+    // create a cost function
+    auto costFunc = PriorEqualityFactor<3>::Create(prior, weight);
+
+    // prior
+    costFunc->AddParameterBlock(3);
+
+    // set Residuals
+    costFunc->SetNumResiduals(3);
+
+    // organize the param block vector
+    std::vector<double *> paramBlockVec;
+
+    paramBlockVec.push_back(address.data());
+
+    // pass to problem
+    this->AddResidualBlock(costFunc, nullptr, paramBlockVec);
+}
+
+void Estimator::AddPriorEqualityConstraint(const Eigen::Vector6d &prior,
+                                           Eigen::Vector6d &address,
+                                           double weight) {
+    // create a cost function
+    auto costFunc = PriorEqualityFactor<6>::Create(prior, weight);
+
+    // prior
+    costFunc->AddParameterBlock(6);
+
+    // set Residuals
+    costFunc->SetNumResiduals(6);
+
+    // organize the param block vector
+    std::vector<double *> paramBlockVec;
+
+    paramBlockVec.push_back(address.data());
+
+    // pass to problem
+    this->AddResidualBlock(costFunc, nullptr, paramBlockVec);
+}
+
+void Estimator::AddPriorEqualityConstraint(const Sophus::SO3d &prior,
+                                           Sophus::SO3d &address,
+                                           double weight) {
+    // create a cost function
+    auto costFunc = PriorEqualityFactor<4>::Create(prior, weight);
+
+    // prior
+    costFunc->AddParameterBlock(4);
+
+    // set Residuals
+    costFunc->SetNumResiduals(4);
+
+    // organize the param block vector
+    std::vector<double *> paramBlockVec;
+
+    paramBlockVec.push_back(address.data());
 
     // pass to problem
     this->AddResidualBlock(costFunc, nullptr, paramBlockVec);

--- a/src/calib/spat_temp_priori.cpp
+++ b/src/calib/spat_temp_priori.cpp
@@ -68,6 +68,16 @@ const std::map<std::string, double>& SpatialTemporalPriori::GetReadout() const {
     return RS_READOUT;
 }
 
+std::optional<Eigen::Vector3d> SpatialTemporalPriori::GetGravity() const {
+    if (GRAVITY == Eigen::Vector3d::Zero())
+        return {};
+    return GRAVITY;
+}
+
+const std::map<std::string, double>& SpatialTemporalPriori::GetMinVisualScale() const {
+    return MIN_VISUAL_SCALE;
+}
+
 bool SpatialTemporalPriori::HasSO3ToBr(const std::string& topic) const {
     return hasSO3ToBr.find(topic) != hasSO3ToBr.end();
 }
@@ -238,6 +248,23 @@ void SpatialTemporalPriori::CheckValidityWithConfigor() const {
                          readout, sensor, RT_PADDING);
         }
     }
+
+    if (GRAVITY != Eigen::Vector3d::Zero()) {
+        if (std::abs(GRAVITY.norm() - Configor::Prior::GravityNorm) > 1e-3) {
+            throw Status(Status::ERROR, "the given prior gravity vector [{}, {}, {}] does not have "
+                         "norm equal to Prior::GravityNorm ({})! The vector's norm is: {}.",
+                         GRAVITY.x(), GRAVITY.y(), GRAVITY.z(), Configor::Prior::GravityNorm,
+                         GRAVITY.norm());
+        }
+    }
+
+    for (const auto& [cam, _] : MIN_VISUAL_SCALE) {
+        if (optCamModelType.count(cam) == 0) {
+            throw Status(Status::ERROR, "MIN_VISUAL_SCALE defined for topic '{}' which is not an "
+                         "optical camera topic!", cam);
+        }
+    }
+
     const auto& refImu = Configor::DataStream::ReferIMU;
 
     for (const auto& [fromTo, _] : SO3_Sen1ToSen2) {
@@ -393,6 +420,14 @@ void SpatialTemporalPriori::AddSpatTempPrioriConstraint(Estimator& estimator,
         *data = readout;
         if (estimator.HasParameterBlock(data)) {
             estimator.SetParameterBlockConstant(data);
+        }
+    }
+    const auto gravityPrior = this->GetGravity();
+    if (gravityPrior) {
+        auto gravity = &parMagr.GRAVITY;
+        *gravity = *gravityPrior;
+        if (estimator.HasParameterBlock(gravity->data())) {
+            estimator.SetParameterBlockConstant(gravity->data());
         }
     }
     spdlog::info("add spatial and temp priori constraint finished");

--- a/src/calib/spat_temp_priori.cpp
+++ b/src/calib/spat_temp_priori.cpp
@@ -265,6 +265,18 @@ void SpatialTemporalPriori::CheckValidityWithConfigor() const {
         }
     }
 
+    for (const auto& [topic, weight] : INTRI_WEIGHTS) {
+        if (optCamModelType.count(topic) == 0 &&
+            Configor::DataStream::EventTopics.count(topic) == 0 &&
+            Configor::DataStream::IMUTopics.count(topic) == 0) {
+            throw Status(Status::ERROR, "INTRI_WEIGHTS defined for topic '{}' which is neither IMU "
+                         "nor camera topic!", topic);
+        }
+        if (weight < 0) {
+            throw Status(Status::ERROR, "INTRI_WEIGHTS defined for topic '{}' is negative!");
+        }
+    }
+
     const auto& refImu = Configor::DataStream::ReferIMU;
 
     for (const auto& [fromTo, _] : SO3_Sen1ToSen2) {
@@ -428,6 +440,72 @@ void SpatialTemporalPriori::AddSpatTempPrioriConstraint(Estimator& estimator,
         *gravity = *gravityPrior;
         if (estimator.HasParameterBlock(gravity->data())) {
             estimator.SetParameterBlockConstant(gravity->data());
+        }
+    }
+    for (const auto& [topic, weight] : this->INTRI_WEIGHTS) {
+        if (parMagr.INTRI.IMU.count(topic) > 0) {
+            const auto& intri = parMagr.INTRI.IMU.at(topic);
+            const auto& prioriIntri = parMagr.INTRI.PrioriIMU.at(topic);
+            if (std::isinf(weight)) {
+                // set params constant
+                if (estimator.HasParameterBlock(intri->ACCE.BIAS.data())) {
+                    estimator.SetParameterBlockConstant(intri->ACCE.BIAS.data());
+                }
+                if (estimator.HasParameterBlock(intri->ACCE.MAP_COEFF.data())) {
+                    estimator.SetParameterBlockConstant(intri->ACCE.MAP_COEFF.data());
+                }
+                if (estimator.HasParameterBlock(intri->GYRO.BIAS.data())) {
+                    estimator.SetParameterBlockConstant(intri->GYRO.BIAS.data());
+                }
+                if (estimator.HasParameterBlock(intri->GYRO.MAP_COEFF.data())) {
+                    estimator.SetParameterBlockConstant(intri->GYRO.MAP_COEFF.data());
+                }
+                if (estimator.HasParameterBlock(intri->SO3_AtoG.data())) {
+                    estimator.SetParameterBlockConstant(intri->SO3_AtoG.data());
+                }
+            } else if (std::isfinite(weight)) {
+                estimator.AddPriorEqualityConstraint(
+                    prioriIntri->ACCE.BIAS, intri->ACCE.BIAS, weight);
+                estimator.AddPriorEqualityConstraint(
+                    prioriIntri->ACCE.MAP_COEFF, intri->ACCE.MAP_COEFF, weight);
+                estimator.AddPriorEqualityConstraint(
+                    prioriIntri->GYRO.BIAS, intri->GYRO.BIAS, weight);
+                estimator.AddPriorEqualityConstraint(
+                    prioriIntri->GYRO.MAP_COEFF, intri->GYRO.MAP_COEFF, weight);
+                estimator.AddPriorEqualityConstraint(
+                    prioriIntri->SO3_AtoG, intri->SO3_AtoG, weight);
+            }
+        }
+        if (parMagr.INTRI.Camera.count(topic) > 0 || parMagr.INTRI.RGBD.count(topic) > 0) {
+            const auto isRGBD = parMagr.INTRI.RGBD.count(topic) > 0;
+            const auto& intri = isRGBD ?
+                parMagr.INTRI.RGBD.at(topic)->intri : parMagr.INTRI.Camera.at(topic);
+            const auto& prioriIntri = isRGBD ?
+                parMagr.INTRI.PrioriRGBD.at(topic)->intri : parMagr.INTRI.PrioriCamera.at(topic);
+            if (std::isinf(weight)) {
+                // set params constant
+                if (estimator.HasParameterBlock(intri->FXAddress())) {
+                    estimator.SetParameterBlockConstant(intri->FXAddress());
+                }
+                if (estimator.HasParameterBlock(intri->FYAddress())) {
+                    estimator.SetParameterBlockConstant(intri->FYAddress());
+                }
+                if (estimator.HasParameterBlock(intri->CXAddress())) {
+                    estimator.SetParameterBlockConstant(intri->CXAddress());
+                }
+                if (estimator.HasParameterBlock(intri->CYAddress())) {
+                    estimator.SetParameterBlockConstant(intri->CYAddress());
+                }
+            } else if (std::isfinite(weight)) {
+                estimator.AddPriorEqualityConstraint(
+                    prioriIntri->FXAddress(), intri->FXAddress(), weight);
+                estimator.AddPriorEqualityConstraint(
+                    prioriIntri->FYAddress(), intri->FYAddress(), weight);
+                estimator.AddPriorEqualityConstraint(
+                    prioriIntri->CXAddress(), intri->CXAddress(), weight);
+                estimator.AddPriorEqualityConstraint(
+                    prioriIntri->CYAddress(), intri->CYAddress(), weight);
+            }
         }
     }
     spdlog::info("add spatial and temp priori constraint finished");

--- a/src/calib/spat_temp_priori.cpp
+++ b/src/calib/spat_temp_priori.cpp
@@ -255,6 +255,10 @@ void SpatialTemporalPriori::AddSpatTempPrioriConstraint(Estimator& estimator,
             // only one of the param block has been added to problem, we then add the constraint,
             // to make sure a unique least-squares solution
             estimator.AddPriorExtriSO3Constraint(Sen1ToSen2, rot1, rot2, PrioriWeight);
+            if (sen1 == RefIMU && estimator.HasParameterBlock(rot1->data())) {
+                *rot1 = Sophus::SO3d();
+                estimator.SetParameterBlockConstant(rot1->data());
+            }
         }
     }
     for (const auto& [sensorPair, Sen1InSen2] : this->POS_Sen1InSen2) {
@@ -270,6 +274,10 @@ void SpatialTemporalPriori::AddSpatTempPrioriConstraint(Estimator& estimator,
         } else if (estimator.HasParameterBlock(pos1->data()) ||
                    estimator.HasParameterBlock(pos2->data())) {
             estimator.AddPriorExtriPOSConstraint(Sen1InSen2, pos1, rot2, pos2, PrioriWeight);
+            if (sen1 == RefIMU && estimator.HasParameterBlock(pos1->data())) {
+                *pos1 = Eigen::Vector3d::Zero();
+                estimator.SetParameterBlockConstant(pos1->data());
+            }
         }
     }
     for (const auto& [sensorPair, Sen1ToSen2] : this->TO_Sen1ToSen2) {
@@ -283,6 +291,10 @@ void SpatialTemporalPriori::AddSpatTempPrioriConstraint(Estimator& estimator,
             }
         } else if (estimator.HasParameterBlock(to1) || estimator.HasParameterBlock(to2)) {
             estimator.AddPriorTimeOffsetConstraint(Sen1ToSen2, to1, to2, PrioriWeight);
+            if (sen1 == RefIMU && estimator.HasParameterBlock(to1)) {
+                *to1 = 0.0;
+                estimator.SetParameterBlockConstant(to1);
+            }
         }
     }
     // readout times (we set them as constraints in optimization)

--- a/src/calib/spat_temp_priori.cpp
+++ b/src/calib/spat_temp_priori.cpp
@@ -68,6 +68,71 @@ const std::map<std::string, double>& SpatialTemporalPriori::GetReadout() const {
     return RS_READOUT;
 }
 
+bool SpatialTemporalPriori::HasSO3ToBr(const std::string& topic) const {
+    return hasSO3ToBr.find(topic) != hasSO3ToBr.end();
+}
+
+std::optional<Sophus::SO3d> SpatialTemporalPriori::GetSO3ToBr(const std::string& topic) const {
+    if (!HasSO3ToBr(topic))
+        return {};
+
+    const auto& refImu = Configor::DataStream::ReferIMU;
+
+    for (const auto& [fromTo, so3] : this->SO3_Sen1ToSen2) {
+        const auto& [from, to] = fromTo;
+        if (to == refImu && from == topic) {
+            return so3;
+        } else if (from == refImu && to == topic) {
+            return so3.inverse();
+        }
+    }
+    return {};
+}
+
+bool SpatialTemporalPriori::HasPosInBr(const std::string& topic) const {
+    return hasPosToBr.find(topic) != hasPosToBr.end();
+}
+
+std::optional<Eigen::Vector3d> SpatialTemporalPriori::GetPosInBr(const std::string& topic) const {
+    if (!HasPosInBr(topic))
+        return {};
+
+    const auto& refImu = Configor::DataStream::ReferIMU;
+
+    for (const auto& [fromTo, pos] : this->POS_Sen1InSen2) {
+        const auto& [from, to] = fromTo;
+        if (to == refImu && from == topic) {
+            return pos;
+        } else if (from == refImu && to == topic) {
+            // we know the so3 exists because of the HasPosToBr() check above
+            const auto so3 = GetSO3ToBr(to);
+            return (*so3) * (-pos);
+        }
+    }
+    return {};
+}
+
+bool SpatialTemporalPriori::HasTOToBr(const std::string& topic) const {
+    return hasTOToBr.find(topic) != hasTOToBr.end();
+}
+
+std::optional<double> SpatialTemporalPriori::GetTOToBr(const std::string& topic) const {
+    if (!HasTOToBr(topic))
+        return {};
+
+    const auto& refImu = Configor::DataStream::ReferIMU;
+
+    for (const auto& [fromTo, offset] : this->TO_Sen1ToSen2) {
+        const auto& [from, to] = fromTo;
+        if (to == refImu && from == topic) {
+            return offset;
+        } else if (from == refImu && to == topic) {
+            return -offset;
+        }
+    }
+    return {};
+}
+
 void SpatialTemporalPriori::CheckValidityWithConfigor() const {
     // check map if its ambiguous
     if (auto [res, p] = IsMapAmbiguous(this->SO3_Sen1ToSen2); res) {
@@ -172,6 +237,31 @@ void SpatialTemporalPriori::CheckValidityWithConfigor() const {
                          "{:.3f}]), set a larger padding for readout time!",
                          readout, sensor, RT_PADDING);
         }
+    }
+    const auto& refImu = Configor::DataStream::ReferIMU;
+
+    for (const auto& [fromTo, _] : SO3_Sen1ToSen2) {
+        const auto& [from, to] = fromTo;
+        if (from == refImu)
+            hasSO3ToBr.insert(to);
+        else if (to == refImu)
+            hasSO3ToBr.insert(from);
+    }
+
+    for (const auto& [fromTo, _] : POS_Sen1InSen2) {
+        const auto& [from, to] = fromTo;
+        if (from == refImu)
+            hasPosToBr.insert(to);
+        else if (to == refImu && hasSO3ToBr.find(from) != hasSO3ToBr.end())
+            hasPosToBr.insert(from);
+    }
+
+    for (const auto& [fromTo, _] : TO_Sen1ToSen2) {
+        const auto& [from, to] = fromTo;
+        if (from == refImu)
+            hasTOToBr.insert(to);
+        else if (to == refImu)
+            hasTOToBr.insert(from);
     }
 }
 

--- a/src/config/configor.cpp
+++ b/src/config/configor.cpp
@@ -121,6 +121,7 @@ const double Configor::Prior::LossForReprojFactor = 1.0;
 const double Configor::Prior::LossForOpticalFlowFactor = 30.0;
 
 bool Configor::Prior::OptTemporalParams = {};
+bool Configor::Prior::OptImuNonlinearity = false;
 
 bool Configor::Preference::UseCudaInSolving = {};
 OutputOption Configor::Preference::Outputs = OutputOption::NONE;

--- a/src/config/configor.cpp
+++ b/src/config/configor.cpp
@@ -89,6 +89,7 @@ const std::string Configor::DataStream::PkgPath = ros::package::getPath("ikalibr
 const std::string Configor::DataStream::DebugPath = PkgPath + "/debug/";
 
 std::string Configor::Prior::SpatTempPrioriPath = {};
+std::string Configor::Prior::SplinesPrioriPath = {};
 double Configor::Prior::GravityNorm = {};
 double Configor::Prior::TimeOffsetPadding = {};
 double Configor::Prior::ReadoutTimePadding = {};
@@ -121,6 +122,7 @@ const double Configor::Prior::LossForReprojFactor = 1.0;
 const double Configor::Prior::LossForOpticalFlowFactor = 30.0;
 
 bool Configor::Prior::OptTemporalParams = {};
+bool Configor::Prior::OptSplines = true;
 bool Configor::Prior::OptImuNonlinearity = false;
 
 bool Configor::Preference::UseCudaInSolving = {};

--- a/src/sensor/sensor_model.cpp
+++ b/src/sensor/sensor_model.cpp
@@ -113,8 +113,11 @@ std::string LidarModel::UnsupportedLiDARModelMsg(const std::string &modelStr) {
         "3. Hesai Pandar XT LiDARs: PANDAR_XT_POINTS\n"
         "4.           Livox LiDARs: LIVOX_CUSTOM (the official 'xfer_format'=1, "
         "mid-360 and avia is recommend)\n"
+	"5.       Robosense LiDARs: RSLIDAR_POINTS (tested on RS-Helios-16P)\n"
+        "6.          Ouster LiDARs: OUSTER_POINTS_RING_16 (Ouster pointcloud with "
+	"uint16_t ring field)"
         "...\n"
-        "If you need to use other IMU types, "
+        "If you need to use other LiDAR types, "
         "please 'Issues' us on the profile of the github repository.",
         modelStr);
 }

--- a/src/solver/calib_solver_common_impl.cpp
+++ b/src/solver/calib_solver_common_impl.cpp
@@ -110,6 +110,10 @@ CalibSolver::CalibSolver(CalibDataManager::Ptr calibDataManager,
     _splines = CreateSplineBundle(
         _dataMagr->GetCalibStartTimestamp(), _dataMagr->GetCalibEndTimestamp(),
         Configor::Prior::KnotTimeDist::SO3Spline, Configor::Prior::KnotTimeDist::ScaleSpline);
+    _parMagr->splinesPrioriKnots[Configor::Preference::SO3_SPLINE].resize(
+        _splines->GetSo3Spline(Configor::Preference::SO3_SPLINE).GetKnots().size(), false);
+    _parMagr->splinesPrioriKnots[Configor::Preference::SCALE_SPLINE].resize(
+        _splines->GetRdSpline(Configor::Preference::SCALE_SPLINE).GetKnots().size(), false);
 
     // create viewer
     _viewer = Viewer::Create(_parMagr, _splines);
@@ -133,6 +137,12 @@ CalibSolver::CalibSolver(CalibDataManager::Ptr calibDataManager,
         spdlog::info("priori about spatial and temporal parameters are given: '{}'",
                      Configor::Prior::SpatTempPrioriPath);
     }
+
+    // spline bundle priori
+    if (std::filesystem::exists(Configor::Prior::SplinesPrioriPath)) {
+        LoadSplineBundlePriori(Configor::Prior::SplinesPrioriPath);
+        spdlog::info("priori about splines are given: '{}'", Configor::Prior::SplinesPrioriPath);
+    }
 }
 
 CalibSolver::Ptr CalibSolver::Create(const CalibDataManager::Ptr &calibDataManager,
@@ -149,6 +159,10 @@ CalibSolver::~CalibSolver() {
     while (_viewer->IsActive()) {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
+}
+
+double CalibSolver::GetRawStartTimestamp() const {
+    return _dataMagr->GetRawStartTimestamp();
 }
 
 std::optional<Sophus::SE3d> CalibSolver::CurBrToW(double timeByBr) const {
@@ -275,6 +289,57 @@ CalibSolver::SplineBundleType::Ptr CalibSolver::CreateSplineBundle(double st,
         "dt: '{:.5f}'",
         st, et, so3Dt, scaleDt);
     return SplineBundleType::Create({so3SplineInfo, scaleSplineInfo});
+}
+
+void CalibSolver::LoadSplineBundlePriori(const std::string &splinesPrioriPath) {
+    // Load the format saved by CalibSolverIO::SaveBSplines()
+    auto prioriBundle = SplineBundleType::Create({});
+    std::ifstream file(splinesPrioriPath);
+    auto ar = GetInputArchiveVariant(file, Configor::Preference::OutputDataFormat);
+    double rawStartTime;
+    SerializeByInputArchiveVariant(ar, Configor::Preference::OutputDataFormat,
+                                   cereal::make_nvp("splines", *prioriBundle),
+                                   cereal::make_nvp("start_time", rawStartTime));
+
+    try {
+        auto& spline = _splines->GetSo3Spline(Configor::Preference::SO3_SPLINE);
+        const auto& prioriSpline = prioriBundle->GetSo3Spline(Configor::Preference::SO3_SPLINE);
+        auto& prioriKnots = _parMagr->splinesPrioriKnots.at(Configor::Preference::SO3_SPLINE);
+        size_t numPrioriKnots {0u};
+        for (size_t i = 0; i < spline.GetKnots().size(); ++i) {
+            const double t = spline.MinTime() + static_cast<double>(i) * spline.GetTimeInterval();
+            const double prioriT = t + _dataMagr->GetRawStartTimestamp() - rawStartTime;
+            if (prioriSpline.TimeStampInRange(prioriT)) {
+                const auto [tmp, prioriI] = prioriSpline.ComputeTIndex(prioriT);
+                spline.GetKnot(i) = prioriSpline.GetKnot(prioriI);
+                prioriKnots[i] = true;
+                numPrioriKnots++;
+            }
+        }
+        spdlog::info("priori about SO3 spline are given: '{}' ({} knots)",
+                     splinesPrioriPath, numPrioriKnots);
+    } catch (const std::out_of_range&) {
+    }
+
+    try {
+        auto& spline = _splines->GetRdSpline(Configor::Preference::SCALE_SPLINE);
+        const auto& prioriSpline = prioriBundle->GetRdSpline(Configor::Preference::SCALE_SPLINE);
+        auto& prioriKnots = _parMagr->splinesPrioriKnots.at(Configor::Preference::SCALE_SPLINE);
+        size_t numPrioriKnots {0u};
+        for (size_t i = 0; i < spline.GetKnots().size(); ++i) {
+            const double t = spline.MinTime() + static_cast<double>(i) * spline.GetTimeInterval();
+            const double prioriT = t + _dataMagr->GetRawStartTimestamp() - rawStartTime;
+            if (prioriSpline.TimeStampInRange(prioriT)) {
+                const auto [tmp, prioriI] = prioriSpline.ComputeTIndex(prioriT);
+                spline.GetKnot(i) = prioriSpline.GetKnot(prioriI);
+                prioriKnots[i] = true;
+                numPrioriKnots++;
+            }
+        }
+        spdlog::info("priori about scale spline are given: '{}' ({} knots)",
+                     splinesPrioriPath, numPrioriKnots);
+    } catch (const std::out_of_range&) {
+    }
 }
 
 void CalibSolver::AlignStatesToGravity() const {
@@ -503,6 +568,10 @@ ns_veta::Veta::Ptr CalibSolver::TryLoadSfMData(const std::string &topic,
 
     const auto &nameToOurIdx = info.GetImagesNameToIdx();
     for (const auto &[IdFromColmap, image] : images) {
+	if (nameToOurIdx.find(image.name_) == nameToOurIdx.end()) {
+	    spdlog::warn("Image {} from images.txt not found in info.yaml.", image.name_);
+	    continue;
+	}
         const auto &viewId = nameToOurIdx.at(image.name_);
         const auto &poseId = viewId;
 

--- a/src/solver/calib_solver_init_prep_ii_align_impl.cpp
+++ b/src/solver/calib_solver_init_prep_ii_align_impl.cpp
@@ -32,6 +32,8 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "calib/calib_param_manager.h"
+#include "calib/spat_temp_priori.h"
 #include "solver/calib_solver.h"
 
 namespace {
@@ -41,7 +43,19 @@ bool IKALIBR_UNIQUE_NAME(_2_) = ns_ikalibr::_1_(__FILE__);
 namespace ns_ikalibr {
 
 void CalibSolver::InitPrepInertialInertialAlign() {
-    // There is no need to prepare for inertial-inertial alignment
+    for (const auto& [topic, _] : Configor::DataStream::IMUTopics) {
+        if (const auto so3 = _priori->GetSO3ToBr(topic)) {
+            _parMagr->EXTRI.SO3_BiToBr.at(topic) = *so3;
+            spdlog::info("extrinsic rotation read from priori information for IMU '{}'", topic);
+        }
+    }
+
+    for (const auto& [topic, _] : Configor::DataStream::IMUTopics) {
+        if (const auto offset = _priori->GetTOToBr(topic)) {
+            _parMagr->TEMPORAL.TO_BiToBr.at(topic) = *offset;
+            spdlog::info("time offset read from priori information for IMU '{}'", topic);
+        }
+    }
 }
 
 }  // namespace ns_ikalibr

--- a/src/solver/calib_solver_init_prep_li_align_impl.cpp
+++ b/src/solver/calib_solver_init_prep_li_align_impl.cpp
@@ -35,6 +35,7 @@
 #include "calib/calib_data_manager.h"
 #include "calib/calib_param_manager.h"
 #include "calib/estimator.h"
+#include "calib/spat_temp_priori.h"
 #include "core/lidar_odometer.h"
 #include "core/rotation_estimator.h"
 #include "core/scan_undistortion.h"
@@ -55,6 +56,21 @@ void CalibSolver::InitPrepLiDARInertialAlign() const {
     }
     const auto &so3Spline = _splines->GetSo3Spline(Configor::Preference::SO3_SPLINE);
     const auto &scaleSpline = _splines->GetRdSpline(Configor::Preference::SCALE_SPLINE);
+
+    for (const auto& [topic, _] : Configor::DataStream::LiDARTopics) {
+        if (const auto so3 = _priori->GetSO3ToBr(topic)) {
+            _parMagr->EXTRI.SO3_LkToBr.at(topic) = *so3;
+            spdlog::info("extrinsic rotation read from priori information for lidar '{}'", topic);
+        }
+    }
+
+    for (const auto& [topic, _] : Configor::DataStream::LiDARTopics) {
+        if (const auto offset = _priori->GetTOToBr(topic)) {
+            _parMagr->TEMPORAL.TO_LkToBr.at(topic) = *offset;
+            spdlog::info("time offset read from priori information for lidar '{}'", topic);
+        }
+    }
+
     /**
      * we throw the head and tail data as the rotations from the fitted SO3 Spline in that range are
      * poor
@@ -70,6 +86,11 @@ void CalibSolver::InitPrepLiDARInertialAlign() const {
      */
     spdlog::info("LiDARs are integrated, initializing extrinsic rotations of LiDARs...");
     for (const auto &[topic, data] : _dataMagr->GetLiDARMeasurements()) {
+        const auto hasSO3 = _priori->HasSO3ToBr(topic);
+        const auto hasTO = _priori->HasTOToBr(topic);
+        if (hasSO3 && (!Configor::Prior::OptTemporalParams || hasTO))
+            continue;
+
         spdlog::info("performing ndt odometer for '{}' for extrinsic rotation initialization...",
                      topic);
 

--- a/src/solver/calib_solver_init_prep_pci_align_impl.cpp
+++ b/src/solver/calib_solver_init_prep_pci_align_impl.cpp
@@ -35,6 +35,7 @@
 #include "calib/calib_data_manager.h"
 #include "calib/calib_param_manager.h"
 #include "calib/estimator.h"
+#include "calib/spat_temp_priori.h"
 #include "core/rotation_estimator.h"
 #include "core/vision_only_sfm.h"
 #include "opencv2/highgui.hpp"
@@ -53,6 +54,21 @@ void CalibSolver::InitPrepPosCameraInertialAlign() const {
     }
     const auto& so3Spline = _splines->GetSo3Spline(Configor::Preference::SO3_SPLINE);
     const auto& scaleSpline = _splines->GetRdSpline(Configor::Preference::SCALE_SPLINE);
+
+    for (const auto& [topic, _] : Configor::DataStream::PosCameraTopics()) {
+        if (const auto so3 = _priori->GetSO3ToBr(topic)) {
+            _parMagr->EXTRI.SO3_CmToBr.at(topic) = *so3;
+            spdlog::info("extrinsic rotation read from priori information for camera '{}'", topic);
+        }
+    }
+
+    for (const auto& [topic, _] : Configor::DataStream::PosCameraTopics()) {
+        if (const auto offset = _priori->GetTOToBr(topic)) {
+            _parMagr->TEMPORAL.TO_CmToBr.at(topic) = *offset;
+            spdlog::info("time offset read from priori information for camera '{}'", topic);
+        }
+    }
+
     /**
      * we throw the head and tail data as the rotations from the fitted SO3 Spline in that range are
      * poor
@@ -74,6 +90,11 @@ void CalibSolver::InitPrepPosCameraInertialAlign() const {
     // the min distance between two features (to ensure features are distributed uniformly)
     constexpr int minDist = 25;
     for (const auto& [topic, _] : Configor::DataStream::PosCameraTopics()) {
+        const auto hasSO3 = _priori->HasSO3ToBr(topic);
+        const auto hasTO = _priori->HasTOToBr(topic);
+        if (hasSO3 && (!Configor::Prior::OptTemporalParams || hasTO))
+            continue;
+
         const auto& frameVec = _dataMagr->GetCameraMeasurements(topic);
         spdlog::info(
             "perform rotation-only visual odometer to recover extrinsic rotations for '{}'...",
@@ -96,6 +117,8 @@ void CalibSolver::InitPrepPosCameraInertialAlign() const {
                 spdlog::warn(
                     "tracking failed when grab the '{}' image frame!!! try to reinitialize", i);
             }
+            if (hasSO3)
+                continue;
 
             // we do not want to try to recover the extrinsic rotation too frequent
             if ((odometer->GetRotations().size() < 50) ||
@@ -115,13 +138,15 @@ void CalibSolver::InitPrepPosCameraInertialAlign() const {
                 break;
             }
         }
-        if (!rotEstimator->SolveStatus()) {
-            throw Status(Status::ERROR,
-                         "initialize rotation 'SO3_CmToBr' failed, this may be related to "
-                         "insufficiently excited motion or bad images.");
-        } else {
-            spdlog::info("extrinsic rotation of '{}' is recovered using '{:06}' frames", topic,
-                         odometer->GetRotations().size());
+        if (!hasSO3) {
+            if (!rotEstimator->SolveStatus()) {
+                throw Status(Status::ERROR,
+                             "initialize rotation 'SO3_CmToBr' failed, this may be related to "
+                             "insufficiently excited motion or bad images.");
+            } else {
+                spdlog::info("extrinsic rotation of '{}' is recovered using '{:06}' frames", topic,
+                             odometer->GetRotations().size());
+            }
         }
         _viewer->UpdateSensorViewer();
 
@@ -141,6 +166,9 @@ void CalibSolver::InitPrepPosCameraInertialAlign() const {
 
         // perform time offset estimation and extrinsic rotation refinement
         for (const auto& [topic, _] : Configor::DataStream::PosCameraTopics()) {
+            if (_priori->HasTOToBr(topic))
+                continue;
+
             const auto& rotations = rotOnlyOdom.at(topic)->GetRotations();
             // this field should be zero here
             double TO_CmToBr = _parMagr->TEMPORAL.TO_CmToBr.at(topic);

--- a/src/solver/calib_solver_init_sen_inertial_align_impl.cpp
+++ b/src/solver/calib_solver_init_sen_inertial_align_impl.cpp
@@ -114,7 +114,7 @@ void CalibSolver::InitSensorInertialAlign() const {
             std::max(1, int(DESIRED_TIME_INTERVAL * _dataMagr->GetLiDARAvgFrequency(lidarTopic)));
 
         spdlog::info("add lidar-inertial alignment factors for '{}' and '{}', align step: {}",
-                     lidarTopic, Configor::DataStream::ReferIMU);
+                     lidarTopic, Configor::DataStream::ReferIMU, ALIGN_STEP);
 
         for (int i = 0; i < static_cast<int>(poseSeq.size()) - ALIGN_STEP; ++i) {
             const auto &sPose = poseSeq.at(i), ePose = poseSeq.at(i + ALIGN_STEP);
@@ -254,7 +254,7 @@ void CalibSolver::InitSensorInertialAlign() const {
                     Configor::DataStream::IMUTopics.at(topic).AcceWeight);
                 ++count;
             }
-            spdlog::info("constraint count of inertial alignment for '{}': {}", topic,
+            spdlog::info("constraint count of inertial alignment for '{}'-'{}': {}", topic,
                          Configor::DataStream::ReferIMU, count);
         }
     }

--- a/src/solver/calib_solver_init_sen_inertial_align_impl.cpp
+++ b/src/solver/calib_solver_init_sen_inertial_align_impl.cpp
@@ -219,6 +219,11 @@ void CalibSolver::InitSensorInertialAlign() const {
         spdlog::info("add visual-inertial alignment factors for '{}' and '{}', align step: {}",
                      camTopic, Configor::DataStream::ReferIMU, ALIGN_STEP);
 
+        std::optional<double> minScale;
+        if (_priori->GetMinVisualScale().count(camTopic) > 0) {
+            minScale = _priori->GetMinVisualScale().at(camTopic);
+        }
+
         for (int i = 0; i < static_cast<int>(constructedFrames.size()) - ALIGN_STEP; ++i) {
             const auto &sPose = constructedFrames.at(i);
             const auto &ePose = constructedFrames.at(i + ALIGN_STEP);
@@ -245,6 +250,10 @@ void CalibSolver::InitSensorInertialAlign() const {
                 &scale,                               // the visual scale (to be estimated)
                 camOptOption,                         // the optimize option
                 weight);                              // the weigh
+
+            if (minScale) {
+                estimator->SetParameterLowerBound(&scale, 0, *minScale);
+            }
         }
     }
 

--- a/src/solver/calib_solver_init_sen_inertial_align_impl.cpp
+++ b/src/solver/calib_solver_init_sen_inertial_align_impl.cpp
@@ -35,6 +35,7 @@
 #include "calib/calib_data_manager.h"
 #include "calib/calib_param_manager.h"
 #include "calib/estimator.h"
+#include "calib/spat_temp_priori.h"
 #include "core/lidar_odometer.h"
 #include "solver/calib_solver.h"
 #include "util/utils_tpl.hpp"
@@ -102,6 +103,14 @@ void CalibSolver::InitSensorInertialAlign() const {
         const auto &poseSeq = odometer->GetOdomPoseVec();
         double TO_LkToBr = _parMagr->TEMPORAL.TO_LkToBr.at(lidarTopic);
 
+        auto lidarOptOption = optOption;
+        if (const auto pos = _priori->GetPosInBr(lidarTopic)) {
+            _parMagr->EXTRI.POS_LkInBr.at(lidarTopic) = *pos;
+            spdlog::info("extrinsic translation read from priori information for lidar '{}'",
+                lidarTopic);
+            lidarOptOption &= ~OptOption::OPT_POS_LkInBr;
+        }
+
         // create linear velocity sequence
         linVelSeqLk[lidarTopic] =
             std::vector<Eigen::Vector3d>(poseSeq.size(), Eigen::Vector3d::Zero());
@@ -136,7 +145,7 @@ void CalibSolver::InitSensorInertialAlign() const {
                 odometer->GetMapTime(),                 // the map time
                 &curLidarLinVelSeq.at(i),               // the start velocity (to be estimated)
                 &curLidarLinVelSeq.at(i + ALIGN_STEP),  // the end velocity (to be estimated)
-                optOption,                              // the optimize option
+                lidarOptOption,                         // the optimize option
                 weight);                                // the weigh
         }
     }
@@ -185,6 +194,14 @@ void CalibSolver::InitSensorInertialAlign() const {
                                            frame->GetTimestamp());
         }
 
+        auto camOptOption = optOption;
+        if (const auto pos = _priori->GetPosInBr(camTopic)) {
+            _parMagr->EXTRI.POS_CmInBr.at(camTopic) = *pos;
+            spdlog::info("extrinsic translation read from priori information for camera '{}'",
+                camTopic);
+            camOptOption &= ~OptOption::OPT_POS_CmInBr;
+        }
+
         // create linear velocity sequence
         linVelSeqCm[camTopic] =
             std::vector<Eigen::Vector3d>(constructedFrames.size(), Eigen::Vector3d::Zero());
@@ -226,7 +243,7 @@ void CalibSolver::InitSensorInertialAlign() const {
                 &curCamLinVelSeq.at(i),               // the start velocity (to be estimated)
                 &curCamLinVelSeq.at(i + ALIGN_STEP),  // the end velocity (to be estimated)
                 &scale,                               // the visual scale (to be estimated)
-                optOption,                            // the optimize option
+                camOptOption,                         // the optimize option
                 weight);                              // the weigh
         }
     }
@@ -236,6 +253,15 @@ void CalibSolver::InitSensorInertialAlign() const {
     std::vector<Eigen::Vector3d> linVelSeqBr(std::floor((et - st) / dt), Eigen::Vector3d::Zero());
     if (Configor::DataStream::IMUTopics.size() >= 2) {
         for (const auto &[topic, frames] : _dataMagr->GetIMUMeasurements()) {
+            auto imuOptOption = optOption;
+            const auto pos = _priori->GetPosInBr(topic);
+            if (topic != Configor::DataStream::ReferIMU && pos) {
+                _parMagr->EXTRI.POS_BiInBr.at(topic) = *pos;
+                spdlog::info("extrinsic translation read from priori information for IMU '{}'",
+                    topic);
+                imuOptOption &= ~OptOption::OPT_POS_BiInBr;
+            }
+
             spdlog::info("add inertial alignment factors for '{}'...", topic);
             int count = 0;
             for (int i = 0; i < static_cast<int>(linVelSeqBr.size()) - 1; ++i) {
@@ -244,13 +270,13 @@ void CalibSolver::InitSensorInertialAlign() const {
                 Eigen::Vector3d *sVel = &linVelSeqBr.at(sIdx), *eVel = &linVelSeqBr.at(eIdx);
 
                 estimator->AddInertialAlignment(
-                    frames,     // imu frames
-                    topic,      // the ros topic of this imu
-                    sTimeByBr,  // the start time stamped by the reference imu
-                    eTimeByBr,  // the end time stamped by the reference imu
-                    sVel,       // the start velocity (to be estimated)
-                    eVel,       // the end velocity (to be estimated)
-                    optOption,  // the optimize option
+                    frames,        // imu frames
+                    topic,         // the ros topic of this imu
+                    sTimeByBr,     // the start time stamped by the reference imu
+                    eTimeByBr,     // the end time stamped by the reference imu
+                    sVel,          // the start velocity (to be estimated)
+                    eVel,          // the end velocity (to be estimated)
+                    imuOptOption,  // the optimize option
                     Configor::DataStream::IMUTopics.at(topic).AcceWeight);
                 ++count;
             }
@@ -265,6 +291,14 @@ void CalibSolver::InitSensorInertialAlign() const {
         double TO_RjToBr = _parMagr->TEMPORAL.TO_RjToBr.at(radarTopic);
 
         const auto &refIMUFrames = _dataMagr->GetIMUMeasurements(Configor::DataStream::ReferIMU);
+
+        auto radarOptOption = optOption;
+        if (const auto pos = _priori->GetPosInBr(radarTopic)) {
+            _parMagr->EXTRI.POS_RjInBr.at(radarTopic) = *pos;
+            spdlog::info("extrinsic translation read from priori information for radar '{}'",
+                radarTopic);
+            radarOptOption &= ~OptOption::OPT_POS_RjInBr;
+        }
 
         const int ALIGN_STEP =
             std::max(1, int(DESIRED_TIME_INTERVAL * _dataMagr->GetRadarAvgFrequency(radarTopic)));
@@ -308,7 +342,7 @@ void CalibSolver::InitSensorInertialAlign() const {
                 radarTopic,                      // the ros topic of this radar
                 sArray,                          // the start target array
                 eArray,                          // the end target array
-                optOption,                       // the optimization option
+                radarOptOption,                  // the optimization option
                 weight);                         // the weight
             ++count;
         }
@@ -322,6 +356,14 @@ void CalibSolver::InitSensorInertialAlign() const {
         double TO_DnToBr = _parMagr->TEMPORAL.TO_DnToBr.at(rgbdTopic);
 
         const auto &frames = _dataMagr->GetIMUMeasurements(Configor::DataStream::ReferIMU);
+
+        auto rgbdOptOption = optOption;
+        if (const auto pos = _priori->GetPosInBr(rgbdTopic)) {
+            _parMagr->EXTRI.POS_DnInBr.at(rgbdTopic) = *pos;
+            spdlog::info("extrinsic translation read from priori information for rgbd camera '{}'",
+                rgbdTopic);
+            rgbdOptOption &= ~OptOption::OPT_POS_DnInBr;
+        }
 
         const int ALIGN_STEP =
             std::max(1, int(DESIRED_TIME_INTERVAL * _dataMagr->GetRGBDAvgFrequency(rgbdTopic)));
@@ -351,7 +393,7 @@ void CalibSolver::InitSensorInertialAlign() const {
                 rgbdTopic,                         // the ros topic of this rgbd camera
                 bodyFrameVels.at(i),               // the start velocity
                 bodyFrameVels.at(i + ALIGN_STEP),  // the end velocity
-                optOption,                         // the optimization option
+                rgbdOptOption,                     // the optimization option
                 weight);                           // the weight
             ++count;
         }
@@ -365,6 +407,14 @@ void CalibSolver::InitSensorInertialAlign() const {
         double weight = Configor::DataStream::CameraTopics.at(topic).Weight;
         double TO_CmToBr = _parMagr->TEMPORAL.TO_CmToBr.at(topic);
         const auto &frames = _dataMagr->GetIMUMeasurements(Configor::DataStream::ReferIMU);
+
+        auto camOptOption = optOption;
+        if (const auto pos = _priori->GetPosInBr(topic)) {
+            _parMagr->EXTRI.POS_CmInBr.at(topic) = *pos;
+            spdlog::info("extrinsic translation read from priori information for camera '{}'",
+                topic);
+            camOptOption &= ~OptOption::OPT_POS_CmInBr;
+        }
 
         const int ALIGN_STEP =
             std::max(1, int(DESIRED_TIME_INTERVAL * _dataMagr->GetCameraAvgFrequency(topic)));
@@ -401,7 +451,7 @@ void CalibSolver::InitSensorInertialAlign() const {
                 &curVelScales.at(i),               // the scale of start velocity to be estimated
                 velDirs.at(i + ALIGN_STEP),        // the direction of the end velocity
                 &curVelScales.at(i + ALIGN_STEP),  // the scale of end velocity to be estimated
-                optOption,                         // the optimization option
+                camOptOption,                      // the optimization option
                 weight);                           // the weight
             ++count;
         }
@@ -415,6 +465,14 @@ void CalibSolver::InitSensorInertialAlign() const {
         double weight = Configor::DataStream::EventTopics.at(topic).Weight;
         double TO_EsToBr = _parMagr->TEMPORAL.TO_EsToBr.at(topic);
         const auto &frames = _dataMagr->GetIMUMeasurements(Configor::DataStream::ReferIMU);
+
+        auto eventOptOption = optOption;
+        if (const auto pos = _priori->GetPosInBr(topic)) {
+            _parMagr->EXTRI.POS_EsInBr.at(topic) = *pos;
+            spdlog::info("extrinsic translation read from priori information for event camera '{}'",
+                topic);
+            eventOptOption &= ~OptOption::OPT_POS_EsInBr;
+        }
 
         double freq =
             static_cast<double>(velDirs.size()) / (velDirs.back().first - velDirs.front().first);
@@ -450,7 +508,7 @@ void CalibSolver::InitSensorInertialAlign() const {
                 &curVelScales.at(i),               // the scale of start velocity to be estimated
                 velDirs.at(i + ALIGN_STEP),        // the direction of the end velocity
                 &curVelScales.at(i + ALIGN_STEP),  // the scale of end velocity to be estimated
-                optOption,                         // the optimization option
+                eventOptOption,                    // the optimization option
                 weight);                           // the weight
             ++count;
         }

--- a/src/solver/calib_solver_io.cpp
+++ b/src/solver/calib_solver_io.cpp
@@ -158,8 +158,10 @@ void CalibSolverIO::SaveBSplines(int hz) const {
         auto filename = saveDir + "/knots" + Configor::GetFormatExtension();
         std::ofstream file(filename);
         auto ar = GetOutputArchiveVariant(file, Configor::Preference::OutputDataFormat);
+        const double st = _solver->GetRawStartTimestamp();
         SerializeByOutputArchiveVariant(ar, Configor::Preference::OutputDataFormat,
-                                        cereal::make_nvp("splines", *_solver->_splines));
+                                        cereal::make_nvp("splines", *_solver->_splines),
+                                        cereal::make_nvp("start_time", st));
     }
     spdlog::info("saving splines finished!");
 }


### PR DESCRIPTION
This PR adds several improvements. They are mostly independent, but for simplicity, I've chained them all on a single branch. However, each improvement is a separate commit, so it should be easy to cherry pick if you only want some of the improvements.

Improvements:
- This also includes #40.
- Allow optimizing IMU nonlinearity.
- Fix for cases when RefIMU is given as Sen1 in SpatTempPriori (the RefImu extrinsics should never be optimized)
- Allow specifying priors on gravity direction.
- Allow specifying lower bound on visual scale for pos cameras
- Allow specifying weight for intrinsics priors so that the optimized values do not diverge too far
- Added the option to load already computed knots from a previous run and use these knots either as just initialization, or also as a constraint.

This PR brings a few changes to the config and spat-temp-priori YAML files. They have all been documented and all YAMLs in this repo were fixed.

It also changes the format of knots.yaml by adding the initial timestamp so that the knots can be successfully merged with different knots (this is mostly needed because of topic alignment).